### PR TITLE
fixed bug in MktListing

### DIFF
--- a/src/components/MktListing.vue
+++ b/src/components/MktListing.vue
@@ -43,6 +43,7 @@
           <b-button
             v-bind:itemid="item.id"
             v-bind:collectionName="collectionName"
+            v-bind:subCollectionName="subCollectionName"
             v-on:click="route($event)"
           >
             Details


### PR DESCRIPTION
originally redirected to an empty page when you click on "Details" button after searching